### PR TITLE
Fix for error:  TypeError: Object of type RepeatedScalarFieldContainer is not JSON serializable 

### DIFF
--- a/PolarConnect.py
+++ b/PolarConnect.py
@@ -912,7 +912,7 @@ class PolarConnect:
         if query is None:
             return []
         else:
-            return list(map(int, self.collection().findNotes(query)))
+            return list(map(int, self.collection().findCards(query)))
 
 
     @api()

--- a/PolarConnect.py
+++ b/PolarConnect.py
@@ -904,7 +904,7 @@ class PolarConnect:
         if query is None:
             return []
         else:
-            return self.collection().findNotes(query)
+            return list(map(int, self.collection().findNotes(query)))
 
 
     @api()
@@ -912,7 +912,7 @@ class PolarConnect:
         if query is None:
             return []
         else:
-            return self.collection().findCards(query)
+            return list(map(int, self.collection().findNotes(query)))
 
 
     @api()
@@ -1005,7 +1005,7 @@ class PolarConnect:
             else:
                 browser.onSearchActivated()
 
-        return browser.model.cards
+        return list(map(int, browser.model.cards))
 
 
     @api()


### PR DESCRIPTION
In recent versions of Anki, the polar connect add-on does not work and crashes with the above error. A similar error was fixed in the Anki Connect add-on, and it seems to work here too.

Tested on Anki version 2.1.26

See:
[https://github.com/FooSoft/anki-connect/commit/e01544a538cf2efc9c72a516435ad85292c13f0f]()
[https://github.com/FooSoft/anki-connect/commit/aa38f68b5e0737594fa7279e07cf63de86997658]()

